### PR TITLE
fixed titanium armor material attribute values

### DIFF
--- a/src/main/java/net/marblednull/mcore/util/McoreArmorMaterials.java
+++ b/src/main/java/net/marblednull/mcore/util/McoreArmorMaterials.java
@@ -16,7 +16,7 @@ public enum McoreArmorMaterials implements ArmorMaterial {
             SoundEvents.ARMOR_EQUIP_NETHERITE, 0f, 0f, () ->
             Ingredient.of(ModItems.STEEL_INGOT.get())),
 
-    TITANIUM("titanium", 15, new int[]{3, 6, 8, 3}, 10,
+    TITANIUM("titanium", 15, new int[]{3, 8, 6, 3}, 10,
             SoundEvents.ARMOR_EQUIP_NETHERITE, 3f, 0.1f, () ->
             Ingredient.of(ModItems.TITANIUM_INGOT.get()));
 


### PR DESCRIPTION
This pull request fixes the issue with mixed-up attribute values for the armor in the titanium armor. The changes restore the correct order and assignment of these values, resolving the previous issue.